### PR TITLE
Create harbour-encode-sv.ts

### DIFF
--- a/translations/harbour-encode-sv.ts
+++ b/translations/harbour-encode-sv.ts
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
+<context>
+    <name>AboutPage</name>
+    <message>
+        <source>An app to encode audio&amp;video files based on ffmpeg.</source>
+        <translation>En app för att koda om ljud- &amp; filmfiler baserat på ffmpeg.</translation>
+    </message>
+</context>
+<context>
+    <name>CoverPage</name>
+    <message>
+        <source>My Cover</source>
+        <translation>Min programminiatyr</translation>
+    </message>
+</context>
+<context>
+    <name>DetailsSettings</name>
+    <message>
+        <source>Audio Settings</source>
+        <translation>Ljudinställningar</translation>
+    </message>
+    <message>
+        <source>Video Settings</source>
+        <translation>Filminställningar</translation>
+    </message>
+    <message>
+        <source>Codec:</source>
+        <translation>Kodek:</translation>
+    </message>
+    <message>
+        <source>Bitrate</source>
+        <translation>Bithastighet</translation>
+    </message>
+    <message>
+        <source>Set bitrate in kbps</source>
+        <translation>Ange bithastighet i kbps</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation>Kanal</translation>
+    </message>
+    <message>
+        <source>Set number of available channels</source>
+        <translation>Ange antal tillgängliga kanaler</translation>
+    </message>
+    <message>
+        <source>Sampling Frequency:</source>
+        <translation>Samplingsfrekvens:</translation>
+    </message>
+    <message>
+        <source>Language Channel</source>
+        <translation>Språkkanal</translation>
+    </message>
+    <message>
+        <source>Set language channel number</source>
+        <translation>Ange språkkanalnummer</translation>
+    </message>
+    <message>
+        <source>Resolution:</source>
+        <translation>Upplösning:</translation>
+    </message>
+    <message>
+        <source>Aspect:</source>
+        <translation>Förhållande:</translation>
+    </message>
+</context>
+<context>
+    <name>FirstPage</name>
+    <message>
+        <source>Open File</source>
+        <translation>Öppna fil</translation>
+    </message>
+    <message>
+        <source>Encode</source>
+        <translation>Koda om</translation>
+    </message>
+    <message>
+        <source>Video</source>
+        <translation>Film</translation>
+    </message>
+    <message>
+        <source>Codec: </source>
+        <translation>Kodek: </translation>
+    </message>
+    <message>
+        <source>Bitrate: </source>
+        <translation>Bithastighet: </translation>
+    </message>
+    <message>
+        <source>Resolution: </source>
+        <translation>Upplösning: </translation>
+    </message>
+    <message>
+        <source>Aspect Ratio: </source>
+        <translation>Bildförhållande: </translation>
+    </message>
+    <message>
+        <source>Audio</source>
+        <translation>Ljud</translation>
+    </message>
+    <message>
+        <source>Channel(s): </source>
+        <translation>Kanal(er): </translation>
+    </message>
+    <message>
+        <source>Language: </source>
+        <translation>Språk: </translation>
+    </message>
+    <message>
+        <source>Samplerate: </source>
+        <translation>Samplingsfrekvens: </translation>
+    </message>
+    <message>
+        <source>Target Container:</source>
+        <translation>Målbehållare:</translation>
+    </message>
+    <message>
+        <source>Encoding file.
+This might take a while...</source>
+        <translation>Kodar om filen.
+Detta kan ta en stund...</translation>
+    </message>
+    <message>
+        <source>Dismiss</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <source>Encoding successful.
+File saved to </source>
+        <translation>Omkodning slutförd.
+Filen sparad i </translation>
+    </message>
+</context>
+<context>
+    <name>OpenDialog</name>
+    <message>
+        <source>Open file</source>
+        <translation>Öppna fil</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Swedish translation if wanted.

Great app! could become handy. I've listed the missing translation strings that I found, below. Not to rush you. That's just the way I am.  ;-)

-----------------------------------------------------------
**Main page pull down menu:**
About Encode;

**Open file page pull down menu:**
all the menu

**Target container page:**
Choose Container;Video;Audio;

**Video settings page:**
no change;

**Audio settings page:**
not set;

**About page:**
License: BSD (3-clause);Created by;Sourcecode on Github;